### PR TITLE
fix:support for destroying the nginx config experiments by uid

### DIFF
--- a/exec/nginx/nginx_config.go
+++ b/exec/nginx/nginx_config.go
@@ -183,11 +183,6 @@ func createNewConfig(config *parser.Config, locator string, newKV string) (strin
 }
 
 func (ng *NginxConfigExecutor) stop(ctx context.Context, model *spec.ExpModel) *spec.Response {
-	mode := model.ActionFlags["mode"]
-	if mode != "" {
-		return spec.ResponseFailWithFlags(spec.ParameterInvalid, "--mode", mode, fmt.Sprintf("--mode cannot be %s when destroying Nginx config experiment", mode))
-	}
-
 	nginxPath := model.ActionFlags["nginx-path"]
 	return reloadNginxConfig(ng.channel, ctx, nginxPath)
 }


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/chaosblade-io/chaosblade/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
Support for destroying the nginx config experiment by uid


### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
[Failed to destroy the nginx config experiment through uid](https://github.com/chaosblade-io/chaosblade/issues/956)

### Describe how you did it
Remove the  related code.

### Describe how to verify it
**case1**
`./blade create nginx config --mode cmd --block 'http.server[0]' --set-config='listen=8899'  --nginx-path  /usr/local/nginx/sbin/nginx`
**case2**
`./blade create nginx config --mode file --file /usr/local/nginx/conf/nginx1.conf --nginx-path /usr/local/nginx/sbin/nginx`
**destroy by uid**
`./blade destroy uid`


