### PR TITLE
feat:Provides redis connection limit capability

### DIFF
--- a/exec/redis/redis.go
+++ b/exec/redis/redis.go
@@ -43,6 +43,7 @@ func NewRedisCommandSpec() spec.ExpModelCommandSpec {
 				NewCacheExpireActionSpec(),
 				NewCacheLimitActionSpec(),
 				NewCacheHotKeyActionSpec(),
+				NewClientsLimitActionSpec(),
 			},
 			ExpFlags: []spec.ExpFlagSpec{},
 		},

--- a/exec/redis/redis_clients_limit.go
+++ b/exec/redis/redis_clients_limit.go
@@ -1,0 +1,158 @@
+// Package redis-----------------------
+// @author:  xiejunqiao
+// @since:   2024/11/21
+// @desc: //TODO
+// ----------------------------------------
+package redis
+
+import (
+	"context"
+	"fmt"
+	"github.com/chaosblade-io/chaosblade-exec-os/exec/category"
+	"github.com/chaosblade-io/chaosblade-spec-go/log"
+	"github.com/chaosblade-io/chaosblade-spec-go/spec"
+	"github.com/go-redis/redis/v8"
+)
+
+const ClientsLimitBin = "chaos_clientLimit"
+
+type ClientsLimitActionCommandSpec struct {
+	spec.BaseExpActionCommandSpec
+}
+
+func NewClientsLimitActionSpec() spec.ExpActionCommandSpec {
+	return &ClientsLimitActionCommandSpec{
+		spec.BaseExpActionCommandSpec{
+			ActionMatchers: []spec.ExpFlagSpec{},
+			ActionFlags: []spec.ExpFlagSpec{
+				&spec.ExpFlag{
+					Name: "addr",
+					Desc: "The address of redis server",
+				},
+				&spec.ExpFlag{
+					Name: "password",
+					Desc: "The password of server",
+				},
+				&spec.ExpFlag{
+					Name: "count",
+					Desc: "The count of clients",
+				},
+			},
+			ActionExecutor: &ClientsLimitExecutor{},
+			ActionExample: `
+# set maxclients to 100
+blade create redis clients-limit --addr 192.168.56.101:6379 --password 123456  --count 100
+`,
+			ActionPrograms:   []string{ClientsLimitBin},
+			ActionCategories: []string{category.SystemTime},
+		},
+	}
+}
+
+func (*ClientsLimitActionCommandSpec) Name() string {
+	return "clients-limit"
+}
+
+func (*ClientsLimitActionCommandSpec) Aliases() []string {
+	return []string{"cl"}
+}
+
+func (*ClientsLimitActionCommandSpec) ShortDesc() string {
+	return "Clients Limit"
+}
+
+func (k *ClientsLimitActionCommandSpec) LongDesc() string {
+	if k.ActionLongDesc != "" {
+		return k.ActionLongDesc
+	}
+	return "Set the clients of Redis"
+}
+
+func (*ClientsLimitActionCommandSpec) Categories() []string {
+	return []string{category.SystemProcess}
+}
+
+type ClientsLimitExecutor struct {
+	channel spec.Channel
+}
+
+func (cle *ClientsLimitExecutor) Name() string {
+	return "clients-limit"
+}
+
+func (cle *ClientsLimitExecutor) Exec(uid string, ctx context.Context, model *spec.ExpModel) *spec.Response {
+	addrStr := model.ActionFlags["addr"]
+	passwordStr := model.ActionFlags["password"]
+	countStr := model.ActionFlags["count"]
+	cli := redis.NewClient(&redis.Options{
+		Addr:     addrStr,
+		Password: passwordStr,
+	})
+	_, err := cli.Ping(cli.Context()).Result()
+	if err != nil {
+		errMsg := "redis ping error: " + err.Error()
+		log.Errorf(ctx, errMsg)
+		return spec.ResponseFailWithFlags(spec.ActionNotSupport, errMsg)
+	}
+	if _, ok := spec.IsDestroy(ctx); ok {
+		originClientSize, err := cli.Get(cli.Context(), "origin_maxclients_"+uid).Result()
+		if err != nil {
+			errMsg := "redis get origin max clients error: " + err.Error()
+			log.Errorf(ctx, errMsg)
+			return spec.ResponseFailWithFlags(spec.ActionNotSupport, errMsg)
+		}
+		return cle.stop(ctx, cli, originClientSize)
+	}
+	maxClients, err := cli.ConfigGet(cli.Context(), "maxclients").Result()
+	if err != nil {
+		errMsg := "redis get max clients error: " + err.Error()
+		log.Errorf(ctx, errMsg)
+		return spec.ResponseFailWithFlags(spec.ActionNotSupport, errMsg)
+	}
+	originClientsCount := fmt.Sprint(maxClients[1])
+	return cle.start(ctx, uid, cli, originClientsCount, countStr)
+
+}
+func (cle *ClientsLimitExecutor) SetChannel(channel spec.Channel) {
+	cle.channel = channel
+}
+
+func (cle *ClientsLimitExecutor) stop(ctx context.Context, cli *redis.Client, originClients string) *spec.Response {
+	result, err := cli.ConfigSet(cli.Context(), "maxclients", originClients).Result()
+	if err != nil {
+		errMsg := "redis set max clients error: " + err.Error()
+		log.Errorf(ctx, errMsg)
+		return spec.ResponseFailWithFlags(spec.ActionNotSupport, errMsg)
+	}
+	if result != STATUSOK {
+		errMsg := fmt.Sprintf("redis set max clients error: redis command status is %s", result)
+		log.Errorf(ctx, errMsg)
+		return spec.ResponseFailWithFlags(spec.ActionNotSupport, errMsg)
+	}
+
+	return spec.ReturnSuccess("clients limit restored")
+}
+
+func (cle *ClientsLimitExecutor) start(ctx context.Context, uid string, cli *redis.Client, originClientsCount string, countStr string) *spec.Response {
+	result, err := cli.ConfigSet(cli.Context(), "maxclients", countStr).Result()
+	if err != nil {
+		errMsg := "redis set max clients error: " + err.Error()
+		log.Errorf(ctx, errMsg)
+		return spec.ResponseFailWithFlags(spec.ActionNotSupport, errMsg)
+	}
+	if result != STATUSOK {
+		errMsg := fmt.Sprintf("redis set max clients error: redis command status is %s", result)
+		log.Errorf(ctx, errMsg)
+		return spec.ResponseFailWithFlags(spec.ActionNotSupport, errMsg)
+	}
+	originErr := cli.Set(cli.Context(), "origin_maxclients_"+uid, originClientsCount, 0).Err()
+
+	if originErr != nil {
+		errMsg := "redis set origin max clients error: " + originErr.Error()
+		log.Errorf(ctx, errMsg)
+		return spec.ResponseFailWithFlags(spec.ActionNotSupport, errMsg)
+	}
+
+	return spec.ReturnSuccess(uid)
+
+}

--- a/exec/redis/redis_test.go
+++ b/exec/redis/redis_test.go
@@ -1,0 +1,46 @@
+// Package redis-----------------------
+// @author:  xiejunqiao
+// @contact: xiejunqiao@wps.cn
+// @since:   2024/11/25
+// @desc: //TODO
+// ----------------------------------------
+package redis
+
+import (
+	"github.com/go-redis/redis/v8"
+	"log"
+	"testing"
+	"time"
+)
+
+func Test_redis(t *testing.T) {
+	clientList := make([]*redis.Client, 0)
+	for i := 0; i < 100; i++ {
+		cli := redis.NewClient(&redis.Options{
+			Addr: "127.0.0.1:6379",
+		})
+		_, err := cli.Ping(cli.Context()).Result()
+		if err != nil {
+			log.Println("redis ping error: " + err.Error())
+			continue
+		}
+		clientList = append(clientList, cli)
+	}
+	log.Println("clientList len: ", len(clientList))
+	//定时
+	tik := time.NewTicker(time.Second * 10)
+	for {
+		select {
+		case <-tik.C:
+			for _, cli := range clientList {
+				_, err := cli.Ping(cli.Context()).Result()
+				if err != nil {
+					log.Println("redis ping error: " + err.Error())
+					continue
+				}
+			}
+		default:
+
+		}
+	}
+}


### PR DESCRIPTION
提供了redis连接数不足的故障原子能力（Provides redis connection limit capability）
通过限制redis连接数，提供了redis连接数不足的故障原子能力（By limiting the number of redis connections, the failure atomic capability of insufficient redis connections is provided）

Describe how you did it
通过使用go-redis包中的Golang接口修改Redis的maxclients。(Modify maxclients of Redis by using the Golang interface in the go-redis package.)

Describe how to verify it
根据[文档指引](https://chaosblade.io/blog/2023/07/10/chaosblade-contribution-by-redis)，将chaos_middleware打包后，放置到blade的/bin目录下，执行redis的clients-limit故障注入，故障注入的过程如下图所示。

According to the documentation guidelines (https://chaosblade.io/blog/2023/07/10/chaosblade-contribution-by-redis), packaged chaos_middleware, put on/bin directory of the blade, Execute redis clients-limit fault injection. The fault injection process is shown in the following figure.
![389997601-23a29deb-e3ff-4245-8783-b531f135f478](https://github.com/user-attachments/assets/679b38aa-093c-4730-905b-5ba7821434f5)


Special notes for reviews